### PR TITLE
Fix(crash): Use getFragmentContainerID to get the correct container a…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     // Applicaster SDK
-//    def applicasterSDKPath = 'com.applicaster:applicaster-android-sdk:2.36.0'
     def applicasterSDKPath = 'com.applicaster:applicaster-android-sdk:2.33.15'
     // Check if an open SDK is defined - if not use the closed one.
     def devSDK = findProject(':applicaster-android-sdk')
@@ -73,7 +72,17 @@ dependencies {
     else{
         implementation (applicasterSDKPath)
     }
-//    implementation(applicasterSDKPath)
+
+    // Zapp-Root
+    def zappRootSDKPath = 'com.applicaster:zapp-root-android:4.2.1'
+    // Check if an open SDK is defined - if not use the closed one.
+    def rootDev = findProject(':zapp_root')
+    if(rootDev != null){
+        implementation project(path: ':zapp_root')
+    }
+    else{
+        implementation (zappRootSDKPath)
+    }
 
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
 }

--- a/src/main/java/com/applicaster/ParentLockScreenMain.java
+++ b/src/main/java/com/applicaster/ParentLockScreenMain.java
@@ -26,6 +26,7 @@ import com.applicaster.pinlockview.PinLockView;
 import com.applicaster.plugin_manager.screen.PluginScreen;
 import com.applicaster.util.StringUtil;
 import com.applicaster.web.plugins.iai.R;
+import com.applicaster.zapproot.RootActivityManager;
 import com.google.gson.Gson;
 import com.google.gson.internal.LinkedTreeMap;
 import com.google.gson.reflect.TypeToken;
@@ -97,7 +98,7 @@ public class ParentLockScreenMain extends Fragment implements PluginScreen, Hook
 //        startActivityForResult(intent, context, map);
         FragmentTransaction transaction = ((AppCompatActivity) context).getSupportFragmentManager().beginTransaction();
         transaction.setCustomAnimations(R.anim.enter, R.anim.exit, R.anim.fade_in, R.anim.slide_down);
-        transaction.replace(R.id.content_frame, this);
+        transaction.replace(((RootActivityManager.NavigationListener)context).getFragmentContainerID(), this);
         transaction.addToBackStack(null);
         transaction.commit();
     }


### PR DESCRIPTION
…nd avoid crashing

Until now, we assumed that the container id is content_frame, now we take the correct one every time